### PR TITLE
Add .gitignore for build outputs and temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Build outputs
+vs_spredit
+*.[oa]
+*.so
+*.dylib
+*.dll
+*.exe
+*.out
+*.class
+
+# Temporary files
+*~
+*.swp
+*.tmp
+*.log
+.DS_Store
+
+# Test binaries
+test


### PR DESCRIPTION
## Summary
- ignore `vs_spredit` build output
- ignore other build artifacts and temp files

## Testing
- `make test` *(fails: `gtkmm-3.0` and `cairomm-1.0` not found, `test.cpp` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854ce5e3e24832fa2bde5e27c2119fb