### PR TITLE
Add CMake build system and instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.10)
+project(vs_spredit LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(PkgConfig REQUIRED)
+
+pkg_check_modules(GTKMM REQUIRED gtkmm-3.0)
+pkg_check_modules(CAIROMM REQUIRED cairomm-1.0)
+
+add_executable(vs_spredit vegastrike_animation.cpp)
+
+target_include_directories(vs_spredit PRIVATE
+    ${GTKMM_INCLUDE_DIRS}
+    ${CAIROMM_INCLUDE_DIRS}
+)
+
+target_link_directories(vs_spredit PRIVATE
+    ${GTKMM_LIBRARY_DIRS}
+    ${CAIROMM_LIBRARY_DIRS}
+)
+
+target_link_libraries(vs_spredit PRIVATE
+    ${GTKMM_LIBRARIES}
+    ${CAIROMM_LIBRARIES}
+)
+
+target_compile_options(vs_spredit PRIVATE
+    ${GTKMM_CFLAGS_OTHER}
+    ${CAIROMM_CFLAGS_OTHER}
+)
+
+install(TARGETS vs_spredit
+    RUNTIME DESTINATION bin
+)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
 # Vegastrike Sprite Editor
+
 Written in C++ using gtkmm-3.0.
-Compile with make.
+
+## Building with Make
+The legacy Makefile is still provided:
+
+```bash
+make
+```
+
+## Building with CMake
+Alternatively, you can use CMake:
+
+```bash
+mkdir build
+cd build
+cmake ..
+cmake --build .
+```
+
+To install the binary to your system:
+
+```bash
+cmake --install .
+```


### PR DESCRIPTION
## Summary
- add `CMakeLists.txt` with pkg-config lookups for gtkmm and cairomm
- document how to build with CMake in README
- keep the existing Makefile unchanged

## Testing
- `cmake ..`
- `cmake --build .`
- `cmake --install . --prefix ../inst`
- `make -B build`


------
https://chatgpt.com/codex/tasks/task_e_6854cf4adcdc832f8b2f7deb670d89d9