### PR TITLE
Codex/add GitHub actions workflow for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y gtkmm-3.0 cairomm-1.0
+      - name: Build
+        run: make
+      - name: Archive vs_spredit
+        uses: actions/upload-artifact@v3
+        with:
+          name: vs_spredit
+          path: vs_spredit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,21 +3,59 @@ name: Build
 on:
   push:
     branches: [ main ]
+    tags: [ 'v*' ]
   pull_request:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - name: Install dependencies
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtkmm-3.0-dev libcairomm-1.0-dev
-      - name: Build
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew update
+          brew install gtkmm3 cairomm
+      - name: Set up MSYS2
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: >-
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-gtkmm3
+            mingw-w64-x86_64-cairomm
+          msystem: MINGW64
+      - name: Build (Windows)
+        if: runner.os == 'Windows'
+        shell: msys2 {0}
+        run: make
+      - name: Build (Unix)
+        if: runner.os != 'Windows'
         run: make
       - name: Archive vs_spredit
         uses: actions/upload-artifact@v4
         with:
-          name: vs_spredit
-          path: vs_spredit
+          name: vs_spredit-${{ runner.os }}
+          path: |
+            vs_spredit*
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: vs_spredit-*
+          merge-multiple: true
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: vs_spredit*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y gtkmm-3.0 cairomm-1.0
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtkmm-3.0-dev libcairomm-1.0-dev
       - name: Build
         run: make
       - name: Archive vs_spredit
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: vs_spredit
           path: vs_spredit


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build the sprite editor on Ubuntu
- install gtkmm and cairomm from apt
- run make and upload the vs_spredit binary artifact

## Testing
- `make` *(fails: Package 'gtkmm-3.0' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854cf4897ec832f8bde6c2169a78b3e